### PR TITLE
Fix form render

### DIFF
--- a/resources/views/form.blade.php
+++ b/resources/views/form.blade.php
@@ -5,4 +5,6 @@
     @if ($spoofedMethod())
         <input type="hidden" name="_method" value="{{ $method }}">
     @endif
+
+    {{ $slot }}
 </form>

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -14,10 +14,16 @@ class FormTest extends TestCase
     }
 
     /** @test */
-    function renders_a_form_with_post_method()
-    {
-        $this->makeTemplate('<x-form method="post"></x-form>')
+    function renders_a_form_with_post_method() {
+$this->makeTemplate('<x-form method="post"></x-form>')
             ->assertRender(sprintf('<form method="post">%s</form>', $this->csrfField()));
+    }
+
+    /** @test */
+    function renders_a_form_with_fields()
+    {
+        $this->makeTemplate('<x-form><input></x-form>')
+            ->assertRender('<form method="get"><input></form>');
     }
 
     protected function csrfField()


### PR DESCRIPTION
This PR allows us to render custom form components with fields, for example:

```
<x-form>
   <input>
</x-form>
```

will render:

```
<form method="get">
   <input>
</form>
```

Instead of:

```
<form method="get">
</form>
```